### PR TITLE
Fix transfer bin layout on train page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -98,7 +98,7 @@ class _HomeNavState extends State<HomeNav> {
       bottomNavigationBar: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (page != 0) const TransferArea(),
+          if (page != 0 && page != 2) const TransferArea(),
           Container(
             decoration: const BoxDecoration(
               border: Border(top: BorderSide(color: Colors.white, width: 1)),

--- a/lib/pages/train_page.dart
+++ b/lib/pages/train_page.dart
@@ -9,6 +9,7 @@ import '../providers/tug_provider.dart';
 import '../widgets/uld_chip.dart';
 import '../widgets/color_palette.dart';
 import '../widgets/transfer_menu.dart';
+import '../widgets/transfer_area.dart';
 import '../utils/uld_mover.dart';
 
 class _TrainDraft {
@@ -184,54 +185,61 @@ class _TrainPageState extends ConsumerState<TrainPage>
           ),
         ],
       ),
-      body: LayoutBuilder(
-        builder: (context, constraints) {
-          final listHeight = constraints.maxHeight - 72;
-          return Padding(
-            padding: const EdgeInsets.all(12),
-            child: Column(
-              children: [
-                TabBar(
-                  controller: _tabController,
-                  isScrollable: true,
-                  onTap: _showDollyDialog,
-                  tabs: List.generate(
-                    _drafts.length,
-                    (i) => Tab(text: 'Train ${i + 1}'),
-                  ),
-                ),
-                const SizedBox(height: 12),
-                Expanded(
-                  child: SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: List.generate(trains.length, (i) {
-                        final tug = i < tugs.length ? tugs[i] : null;
-                        final train = trains[i];
-                        return Padding(
-                          padding: const EdgeInsets.only(right: 24),
-                          child: Column(
-                            children: [
-                              _buildTug(tug),
-                              const SizedBox(height: 12),
-                              SizedBox(
-                                width: 100,
-                                height: listHeight,
-                                child: _buildDollyStack(
-                                    context, train, outbound),
-                              ),
-                            ],
+      body: Column(
+        children: [
+          Expanded(
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final listHeight = constraints.maxHeight - 72;
+                return Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Column(
+                    children: [
+                      TabBar(
+                        controller: _tabController,
+                        isScrollable: true,
+                        onTap: _showDollyDialog,
+                        tabs: List.generate(
+                          _drafts.length,
+                          (i) => Tab(text: 'Train ${i + 1}'),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Expanded(
+                        child: SingleChildScrollView(
+                          scrollDirection: Axis.horizontal,
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: List.generate(trains.length, (i) {
+                              final tug = i < tugs.length ? tugs[i] : null;
+                              final train = trains[i];
+                              return Padding(
+                                padding: const EdgeInsets.only(right: 24),
+                                child: Column(
+                                  children: [
+                                    _buildTug(tug),
+                                    const SizedBox(height: 12),
+                                    SizedBox(
+                                      width: 100,
+                                      height: listHeight,
+                                      child: _buildDollyStack(
+                                          context, train, outbound),
+                                    ),
+                                  ],
+                                ),
+                              );
+                            }),
                           ),
-                        );
-                      }),
-                    ),
+                        ),
+                      ),
+                    ],
                   ),
-                ),
-              ],
+                );
+              },
             ),
-          );
-        },
+          ),
+          const SizedBox(height: 60, child: TransferArea()),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- ensure `TransferArea` stays pinned at the bottom of the Train page
- keep main content scrollable above the transfer bin
- don't show global `TransferArea` while on the Train page

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687825fd30488331b0f76850e6355164