### PR TITLE
Implement copyWith for ball deck

### DIFF
--- a/lib/providers/ball_deck_provider.dart
+++ b/lib/providers/ball_deck_provider.dart
@@ -15,6 +15,16 @@ class BallDeckState {
   final List<StorageContainer> overflow;
 
   BallDeckState({required this.slots, required this.overflow});
+
+  BallDeckState copyWith({
+    List<StorageContainer?>? slots,
+    List<StorageContainer>? overflow,
+  }) {
+    return BallDeckState(
+      slots: slots ?? this.slots,
+      overflow: overflow ?? this.overflow,
+    );
+  }
 }
 
 class BallDeckNotifier extends StateNotifier<BallDeckState> {


### PR DESCRIPTION
## Summary
- implement `copyWith` for `BallDeckState` so state changes can be done using a convenience method

## Testing
- *No tests run due to missing Flutter SDK*


------
https://chatgpt.com/codex/tasks/task_e_687a62bdd71c8331862a4bec3d3e3fc1