### PR TITLE
Fix setSize call

### DIFF
--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -688,10 +688,7 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
           ),
           ElevatedButton(
             onPressed: () {
-              ref.read(storageProvider.notifier).setSize(
-                    storageCount,
-                    transferBin: ref.read(transferBinProvider),
-                  );
+              ref.read(storageProvider.notifier).setSize(storageCount);
               ScaffoldMessenger.of(context).showSnackBar(
                 const SnackBar(content: Text('Storage slot count updated')),
               );


### PR DESCRIPTION
## Summary
- remove nonexistent `transferBin` argument when resizing storage slots

## Testing
- `flutter test` *(fails: Undefined name 'main')*

------
https://chatgpt.com/codex/tasks/task_e_687a63c9b29083319541bec5b10066d2