### PR TITLE
Refactor ConfigPage to use config provider

### DIFF
--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -1,14 +1,39 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class ConfigPage extends StatelessWidget {
+import '../providers/config_provider.dart';
+
+class ConfigPage extends ConsumerWidget {
   const ConfigPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      backgroundColor: Colors.black,
-      body: Center(
-        child: Text('Config', style: TextStyle(color: Colors.white)),
+  Widget build(BuildContext context, WidgetRef ref) {
+    final config = ref.watch(configProvider);
+    if (config == null) {
+      debugPrint('ConfigPage early exit: config is null');
+      return const Scaffold(
+        appBar: AppBar(title: Text('Config')),
+        body: Center(child: Text('No configuration loaded')),
+      );
+    }
+
+    debugPrint('ConfigPage build with config for ${config.aircraft.typeCode}');
+    return Scaffold(
+      appBar: AppBar(title: const Text('Config')),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Aircraft: ${config.aircraft.typeCode}'),
+              const SizedBox(height: 8),
+              Text('Allowed ULDs: ${config.allowedUlds.length}'),
+              const SizedBox(height: 8),
+              Text('Trains: ${config.trains.length}'),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/providers/config_provider.dart
+++ b/lib/providers/config_provider.dart
@@ -15,4 +15,11 @@ class LoadConfig {
   });
 }
 
-final configProvider = StateProvider<LoadConfig?>((ref) => null);
+final configProvider = StateProvider<LoadConfig?>((ref) {
+  // Default placeholder configuration to ensure provider is non-null.
+  return LoadConfig(
+    aircraft: const Aircraft('UNKNOWN', 'Unknown Aircraft', [], []),
+    allowedUlds: const [],
+    trains: const [],
+  );
+});


### PR DESCRIPTION
## Summary
- Refactor ConfigPage into a ConsumerWidget that watches `configProvider`
- Add debug prints and scaffolded layout for configuration data
- Initialize `configProvider` with a placeholder configuration to avoid null state

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6891031d3b0483319725ca8deefbcc41