### PR TITLE
fix: remove const from config scaffold

### DIFF
--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -11,9 +11,9 @@ class ConfigPage extends ConsumerWidget {
     final config = ref.watch(configProvider);
     if (config == null) {
       debugPrint('ConfigPage early exit: config is null');
-      return const Scaffold(
-        appBar: AppBar(title: Text('Config')),
-        body: Center(child: Text('No configuration loaded')),
+      return Scaffold(
+        appBar: AppBar(title: const Text('Config')),
+        body: const Center(child: Text('No configuration loaded')),
       );
     }
 


### PR DESCRIPTION
## Summary
- fix config page build method: remove const from early Scaffold return to avoid const constructor error

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891073900bc83319db2f8b71eba1e8c