### PR TITLE
Add ball deck slot count slider to config page

### DIFF
--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -71,6 +71,9 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
   /// Drafts for planes.
   List<_PlaneDraft> _planeDrafts = [];
 
+  /// Current ball deck slot count.
+  int _ballDeckCount = 0;
+
   /// Current storage slot count.
   int _storageCount = 0;
 
@@ -145,6 +148,7 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
       );
     });
 
+    _ballDeckCount = ref.read(ballDeckProvider).slots.length;
     _storageCount = ref.read(storageProvider).length;
 
     final planes = ref.read(planesProvider);
@@ -587,6 +591,29 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
               ElevatedButton(
                 onPressed: _addTrain,
                 child: const Text('Add Tug'),
+              ),
+              const SizedBox(height: 24),
+              const Text('Ball Deck Configuration'),
+              const Text('Number of Ball Deck Slots'),
+              Slider(
+                value: _ballDeckCount.toDouble(),
+                min: 0,
+                max: 30,
+                divisions: 30,
+                label: '$_ballDeckCount',
+                onChanged: (v) => setState(() => _ballDeckCount = v.toInt()),
+              ),
+              ElevatedButton(
+                onPressed: () {
+                  ref
+                      .read(ballDeckProvider.notifier)
+                      .setSlotCount(_ballDeckCount);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                        content: Text('Ball deck slot count updated')),
+                  );
+                },
+                child: const Text('Apply'),
               ),
               const SizedBox(height: 24),
               const Text('Storage Configuration'),


### PR DESCRIPTION
## Summary
- add Ball Deck Configuration section to Config Page
- persist ball deck slot count with Hive and update Ball Deck page

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68921c882cbc8331aeb7fbb4679e31a5