### PR TITLE
Reorder ball deck configuration

### DIFF
--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -527,6 +527,28 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
                 ],
               ),
               const SizedBox(height: 24),
+              const Text('Ball Deck Configuration'),
+              Slider(
+                value: _ballDeckCount.toDouble(),
+                min: 0,
+                max: 30,
+                divisions: 30,
+                label: '$_ballDeckCount',
+                onChanged: (v) => setState(() => _ballDeckCount = v.toInt()),
+              ),
+              ElevatedButton(
+                onPressed: () {
+                  ref
+                      .read(ballDeckProvider.notifier)
+                      .setSlotCount(_ballDeckCount);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                        content: Text('Ball deck slot count updated')),
+                  );
+                },
+                child: const Text('Apply'),
+              ),
+              const SizedBox(height: 24),
               const Text('Tug/Train Configuration'),
               const SizedBox(height: 8),
               _trainDrafts.isEmpty
@@ -591,29 +613,6 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
               ElevatedButton(
                 onPressed: _addTrain,
                 child: const Text('Add Tug'),
-              ),
-              const SizedBox(height: 24),
-              const Text('Ball Deck Configuration'),
-              const Text('Number of Ball Deck Slots'),
-              Slider(
-                value: _ballDeckCount.toDouble(),
-                min: 0,
-                max: 30,
-                divisions: 30,
-                label: '$_ballDeckCount',
-                onChanged: (v) => setState(() => _ballDeckCount = v.toInt()),
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  ref
-                      .read(ballDeckProvider.notifier)
-                      .setSlotCount(_ballDeckCount);
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                        content: Text('Ball deck slot count updated')),
-                  );
-                },
-                child: const Text('Apply'),
               ),
               const SizedBox(height: 24),
               const Text('Storage Configuration'),


### PR DESCRIPTION
## Summary
- move Ball Deck Configuration section above Tug/Train Configuration
- remove label 'Number of Ball Deck Slots'

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install flutter` *(fails: package not found)*


------
https://chatgpt.com/codex/tasks/task_e_68921f1cf3c08331a0fd517e9c5694a8