### PR TITLE
fix: persist plane configuration selection

### DIFF
--- a/lib/providers/plane_provider.dart
+++ b/lib/providers/plane_provider.dart
@@ -104,19 +104,17 @@ class PlaneNotifier extends StateNotifier<PlaneState> {
       sequence.order.length,
       null,
     );
-    Future.microtask(() {
-      if (outbound) {
-        state = state.copyWith(
-          outboundSequence: sequence,
-          outboundSlots: newSlots,
-        );
-      } else {
-        state = state.copyWith(
-          inboundSequence: sequence,
-          inboundSlots: newSlots,
-        );
-      }
-    });
+    if (outbound) {
+      state = state.copyWith(
+        outboundSequence: sequence,
+        outboundSlots: newSlots,
+      );
+    } else {
+      state = state.copyWith(
+        inboundSequence: sequence,
+        inboundSlots: newSlots,
+      );
+    }
   }
 
   void placeContainer(


### PR DESCRIPTION
## Summary
- ensure selected plane configuration updates state immediately so saved plane uses the new sequence

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689221fe87208331883572802a440893