### PR TITLE
feat: add transfer bin clear button

### DIFF
--- a/lib/managers/transfer_bin_manager.dart
+++ b/lib/managers/transfer_bin_manager.dart
@@ -120,6 +120,9 @@ class TransferBinManager extends ChangeNotifier {
 
   void clear() {
     _ulds = [];
+    for (final entry in _slots.entries) {
+      _slots[entry.key] = List<StorageContainer?>.filled(entry.value.length, null);
+    }
     _save();
     notifyListeners();
   }

--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -659,6 +659,39 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
                 },
                 child: const Text('Apply'),
               ),
+              const SizedBox(height: 24),
+              const Divider(),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: () async {
+                  final confirm = await showDialog<bool>(
+                    context: context,
+                    builder: (context) => AlertDialog(
+                      title: const Text('Empty Transfer Bin'),
+                      content: const Text(
+                          'Are you sure you want to permanently delete all ULDs in the transfer bin?'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, false),
+                          child: const Text('Cancel'),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, true),
+                          child: const Text('Delete'),
+                        ),
+                      ],
+                    ),
+                  );
+                  if (confirm == true) {
+                    TransferBinManager.instance.clear();
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Transfer bin emptied')),
+                    );
+                  }
+                },
+                style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+                child: const Text('Empty Transfer Bin'),
+              ),
             ],
           ),
         );


### PR DESCRIPTION
## Summary
- allow clearing transfer bin from Config page
- ensure clearing removes all ULDs from persisted slots

## Testing
- `dart format lib/managers/transfer_bin_manager.dart lib/pages/config_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68927425b1dc8331bf727054164e6a21