### PR TITLE
feat: centralize ULD slot management

### DIFF
--- a/lib/managers/uld_placement_manager.dart
+++ b/lib/managers/uld_placement_manager.dart
@@ -1,0 +1,85 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../models/container.dart';
+
+/// Central manager for ULD placement across all zones in the app.
+class ULDPlacementManager {
+  ULDPlacementManager._internal();
+  static final ULDPlacementManager instance = ULDPlacementManager._internal();
+
+  final Box _box = Hive.box('uldPlacementBox');
+
+  static const String _ballDeckKey = 'ballDeck';
+  static const String _planeDeckKey = 'planeDeck';
+  static const String _trainDeckKey = 'trainDeck';
+  static const String _storageKey = 'storage';
+  static const String _transferKey = 'transferBin';
+
+  /// Zone maps
+  final Map<String, StorageContainer> ballDeck = {};
+  final Map<String, StorageContainer> planeDeck = {};
+  final Map<String, StorageContainer> trainDeck = {};
+  final Map<String, StorageContainer> storage = {};
+  final List<StorageContainer> transferBin = [];
+
+  ULDPlacementManager._internal() {
+    final Map? bd = _box.get(_ballDeckKey);
+    if (bd is Map) ballDeck.addAll(bd.cast<String, StorageContainer>());
+
+    final Map? pd = _box.get(_planeDeckKey);
+    if (pd is Map) planeDeck.addAll(pd.cast<String, StorageContainer>());
+
+    final Map? td = _box.get(_trainDeckKey);
+    if (td is Map) trainDeck.addAll(td.cast<String, StorageContainer>());
+
+    final Map? st = _box.get(_storageKey);
+    if (st is Map) storage.addAll(st.cast<String, StorageContainer>());
+
+    final List? tb = _box.get(_transferKey);
+    if (tb is List) transferBin.addAll(List<StorageContainer>.from(tb));
+  }
+
+  void _save() {
+    _box
+      ..put(_ballDeckKey, ballDeck)
+      ..put(_planeDeckKey, planeDeck)
+      ..put(_trainDeckKey, trainDeck)
+      ..put(_storageKey, storage)
+      ..put(_transferKey, transferBin);
+  }
+
+  /// Update the slot count for [zone] and move any containers in now-invalid
+  /// slots to the transfer bin.
+  void updateSlotCount(String zone, int newCount) {
+    final map = _getZoneMap(zone);
+    final removedKeys =
+        map.keys.where((key) => !_slotExists(key, newCount)).toList();
+
+    for (final key in removedKeys) {
+      transferBin.add(map[key]!);
+      map.remove(key);
+    }
+    _save();
+  }
+
+  Map<String, StorageContainer> _getZoneMap(String zone) {
+    switch (zone) {
+      case 'BallDeck':
+        return ballDeck;
+      case 'Plane':
+        return planeDeck;
+      case 'Train':
+        return trainDeck;
+      case 'Storage':
+        return storage;
+      default:
+        throw Exception('Unknown zone: ' + zone);
+    }
+  }
+
+  bool _slotExists(String slotId, int newCount) {
+    final index = int.tryParse(slotId.replaceAll(RegExp(r'[^0-9]'), ''));
+    return index != null && index < newCount;
+  }
+}
+

--- a/lib/providers/ball_deck_provider.dart
+++ b/lib/providers/ball_deck_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 import '../models/container.dart';
 import '../managers/transfer_bin_manager.dart';
+import '../managers/uld_placement_manager.dart';
 
 part 'ball_deck_provider.g.dart';
 
@@ -52,25 +53,15 @@ class BallDeckNotifier extends StateNotifier<BallDeckState> {
   void setSlotCount(
     int count,
   ) {
+    final placement = ULDPlacementManager.instance;
+    placement.updateSlotCount('BallDeck', count);
+
     final manager = TransferBinManager.instance;
-    final slots = List<StorageContainer?>.from(manager.getSlots(_slotsId));
-    int moved = 0;
-
-    for (int i = 0; i < slots.length; i++) {
-      final c = slots[i];
-      if (i >= count && c != null) {
-        debugPrint('Moving ${c.uld} from ball deck slot $i to transfer bin');
-        manager.removeULDFromSlots(c);
-        manager.addULD(c);
-        moved++;
-      }
-    }
-
+    manager.validateSlots(_slotsId, count);
     manager.setSlotCount(_slotsId, count);
 
     state = state.copyWith(slots: manager.getSlots(_slotsId));
     _saveState();
-    debugPrint('Moved $moved ULDs from ball deck to transfer bin');
   }
 
   void addUld(StorageContainer container) {

--- a/lib/providers/plane_provider.dart
+++ b/lib/providers/plane_provider.dart
@@ -3,6 +3,7 @@ import '../models/container.dart';
 import '../models/aircraft.dart';
 import '../models/plane.dart';
 import '../managers/transfer_bin_manager.dart';
+import '../managers/uld_placement_manager.dart';
 
 class PlaneState {
   final LoadingSequence? inboundSequence;
@@ -105,12 +106,7 @@ class PlaneNotifier extends StateNotifier<PlaneState> {
     final current = outbound ? state.outboundSlots : state.inboundSlots;
     final newCount = sequence.order.length;
 
-    if (newCount < current.length) {
-      for (int i = newCount; i < current.length; i++) {
-        final c = current[i];
-        if (c != null) transfer.addULD(c);
-      }
-    }
+    ULDPlacementManager.instance.updateSlotCount('Plane', newCount);
 
     final updated = List<StorageContainer?>.filled(newCount, null);
     final copy = newCount < current.length ? newCount : current.length;

--- a/lib/providers/storage_provider.dart
+++ b/lib/providers/storage_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/container.dart';
 import '../managers/transfer_bin_manager.dart';
+import '../managers/uld_placement_manager.dart';
 
 final storageProvider =
     StateNotifierProvider<StorageNotifier, List<StorageContainer?>>((ref) {
@@ -26,6 +27,7 @@ class StorageNotifier extends StateNotifier<List<StorageContainer?>> {
   }
 
   void setSize(int count) {
+    ULDPlacementManager.instance.updateSlotCount('Storage', count);
     _manager.validateSlots(_pageId, count);
     _manager.setSlotCount(_pageId, count);
     state = _manager.getSlots(_pageId);


### PR DESCRIPTION
## Summary
- add ULDPlacementManager to manage zone maps and transfer bin
- use manager to update slot counts in ball deck, storage, and plane providers

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6892bfd983b8833182e71b3df2b67bf0