### PR TITLE
Fix singleton implementation for ULDPlacementManager

### DIFF
--- a/lib/managers/uld_placement_manager.dart
+++ b/lib/managers/uld_placement_manager.dart
@@ -4,24 +4,6 @@ import '../models/container.dart';
 
 /// Central manager for ULD placement across all zones in the app.
 class ULDPlacementManager {
-  ULDPlacementManager._internal();
-  static final ULDPlacementManager instance = ULDPlacementManager._internal();
-
-  final Box _box = Hive.box('uldPlacementBox');
-
-  static const String _ballDeckKey = 'ballDeck';
-  static const String _planeDeckKey = 'planeDeck';
-  static const String _trainDeckKey = 'trainDeck';
-  static const String _storageKey = 'storage';
-  static const String _transferKey = 'transferBin';
-
-  /// Zone maps
-  final Map<String, StorageContainer> ballDeck = {};
-  final Map<String, StorageContainer> planeDeck = {};
-  final Map<String, StorageContainer> trainDeck = {};
-  final Map<String, StorageContainer> storage = {};
-  final List<StorageContainer> transferBin = [];
-
   ULDPlacementManager._internal() {
     final Map? bd = _box.get(_ballDeckKey);
     if (bd is Map) ballDeck.addAll(bd.cast<String, StorageContainer>());
@@ -38,6 +20,25 @@ class ULDPlacementManager {
     final List? tb = _box.get(_transferKey);
     if (tb is List) transferBin.addAll(List<StorageContainer>.from(tb));
   }
+
+  static final ULDPlacementManager _instance = ULDPlacementManager._internal();
+
+  factory ULDPlacementManager() => _instance;
+
+  final Box _box = Hive.box('uldPlacementBox');
+
+  static const String _ballDeckKey = 'ballDeck';
+  static const String _planeDeckKey = 'planeDeck';
+  static const String _trainDeckKey = 'trainDeck';
+  static const String _storageKey = 'storage';
+  static const String _transferKey = 'transferBin';
+
+  /// Zone maps
+  final Map<String, StorageContainer> ballDeck = {};
+  final Map<String, StorageContainer> planeDeck = {};
+  final Map<String, StorageContainer> trainDeck = {};
+  final Map<String, StorageContainer> storage = {};
+  final List<StorageContainer> transferBin = [];
 
   void _save() {
     _box

--- a/lib/providers/ball_deck_provider.dart
+++ b/lib/providers/ball_deck_provider.dart
@@ -53,7 +53,7 @@ class BallDeckNotifier extends StateNotifier<BallDeckState> {
   void setSlotCount(
     int count,
   ) {
-    final placement = ULDPlacementManager.instance;
+    final placement = ULDPlacementManager();
     placement.updateSlotCount('BallDeck', count);
 
     final manager = TransferBinManager.instance;

--- a/lib/providers/plane_provider.dart
+++ b/lib/providers/plane_provider.dart
@@ -106,7 +106,7 @@ class PlaneNotifier extends StateNotifier<PlaneState> {
     final current = outbound ? state.outboundSlots : state.inboundSlots;
     final newCount = sequence.order.length;
 
-    ULDPlacementManager.instance.updateSlotCount('Plane', newCount);
+    ULDPlacementManager().updateSlotCount('Plane', newCount);
 
     final updated = List<StorageContainer?>.filled(newCount, null);
     final copy = newCount < current.length ? newCount : current.length;

--- a/lib/providers/storage_provider.dart
+++ b/lib/providers/storage_provider.dart
@@ -27,7 +27,7 @@ class StorageNotifier extends StateNotifier<List<StorageContainer?>> {
   }
 
   void setSize(int count) {
-    ULDPlacementManager.instance.updateSlotCount('Storage', count);
+    ULDPlacementManager().updateSlotCount('Storage', count);
     _manager.validateSlots(_pageId, count);
     _manager.setSlotCount(_pageId, count);
     state = _manager.getSlots(_pageId);


### PR DESCRIPTION
## Summary
- fix duplicate constructor in `ULDPlacementManager`
- access `ULDPlacementManager` via factory in providers

## Testing
- `dart format lib/managers/uld_placement_manager.dart lib/providers/plane_provider.dart lib/providers/ball_deck_provider.dart lib/providers/storage_provider.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892c64f1d5c8331ac7f3bdc4856caaf