### PR TITLE
Initialize Hive boxes before app start

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,6 +30,14 @@ void main() async {
   await Future.wait([
     Hive.openBox('ballDeckBox'),
     Hive.openBox('transferBox'),
+    Hive.openBox('uldPlacementBox'),
+    Hive.openBox('configBox'),
+    Hive.openBox('planeBox'),
+    Hive.openBox('planesBox'),
+    Hive.openBox('trainBox'),
+    Hive.openBox('tugBox'),
+    Hive.openBox('tugsBox'),
+    Hive.openBox('uldBox'),
   ]);
 
   runApp(const ProviderScope(child: MyApp()));

--- a/lib/managers/uld_placement_manager.dart
+++ b/lib/managers/uld_placement_manager.dart
@@ -5,6 +5,11 @@ import '../models/container.dart';
 /// Central manager for ULD placement across all zones in the app.
 class ULDPlacementManager {
   ULDPlacementManager._internal() {
+    if (!Hive.isBoxOpen('uldPlacementBox')) {
+      throw HiveError('uldPlacementBox has not been opened');
+    }
+    _box = Hive.box('uldPlacementBox');
+
     final Map? bd = _box.get(_ballDeckKey);
     if (bd is Map) ballDeck.addAll(bd.cast<String, StorageContainer>());
 
@@ -25,7 +30,7 @@ class ULDPlacementManager {
 
   factory ULDPlacementManager() => _instance;
 
-  final Box _box = Hive.box('uldPlacementBox');
+  late final Box _box;
 
   static const String _ballDeckKey = 'ballDeck';
   static const String _planeDeckKey = 'planeDeck';


### PR DESCRIPTION
## Summary
- Open all Hive boxes used across ConfigPage and ULDPlacementManager at startup
- Guard ULDPlacementManager against uninitialized `uldPlacementBox`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892dd39e6a08331a01d5c218c395a9d