### PR TITLE
Handle slot reductions by moving ULDs to transfer bin

### DIFF
--- a/lib/managers/transfer_bin_manager.dart
+++ b/lib/managers/transfer_bin_manager.dart
@@ -103,7 +103,8 @@ class TransferBinManager extends ChangeNotifier {
     for (int i = newSlotCount; i < slots.length; i++) {
       final c = slots[i];
       if (c != null) {
-        debugPrint('Moving ${c.uld} from $pageId index $i to transfer bin');
+        debugPrint(
+            'Moved ULD ${c.uld} from $pageId slot $i to transfer bin');
         addULD(c);
       }
     }

--- a/lib/providers/ball_deck_provider.dart
+++ b/lib/providers/ball_deck_provider.dart
@@ -53,15 +53,15 @@ class BallDeckNotifier extends StateNotifier<BallDeckState> {
   void setSlotCount(
     int count,
   ) {
-    final placement = ULDPlacementManager();
-    placement.updateSlotCount('BallDeck', count);
-
     final manager = TransferBinManager.instance;
     manager.validateSlots(_slotsId, count);
     manager.setSlotCount(_slotsId, count);
 
     state = state.copyWith(slots: manager.getSlots(_slotsId));
     _saveState();
+
+    final placement = ULDPlacementManager();
+    placement.updateSlotCount('BallDeck', count);
   }
 
   void addUld(StorageContainer container) {

--- a/lib/providers/plane_provider.dart
+++ b/lib/providers/plane_provider.dart
@@ -106,7 +106,15 @@ class PlaneNotifier extends StateNotifier<PlaneState> {
     final current = outbound ? state.outboundSlots : state.inboundSlots;
     final newCount = sequence.order.length;
 
-    ULDPlacementManager().updateSlotCount('Plane', newCount);
+    if (newCount < current.length) {
+      for (int i = newCount; i < current.length; i++) {
+        final uld = current[i];
+        if (uld != null) {
+          transfer.addULD(uld);
+          debugPrint('Moved ULD ${uld.uld} from Plane slot $i to transfer bin');
+        }
+      }
+    }
 
     final updated = List<StorageContainer?>.filled(newCount, null);
     final copy = newCount < current.length ? newCount : current.length;
@@ -125,6 +133,8 @@ class PlaneNotifier extends StateNotifier<PlaneState> {
         inboundSlots: updated,
       );
     }
+
+    ULDPlacementManager().updateSlotCount('Plane', newCount);
   }
 
   void placeContainer(

--- a/lib/providers/train_provider.dart
+++ b/lib/providers/train_provider.dart
@@ -60,6 +60,7 @@ class TrainNotifier extends StateNotifier<List<Train>> {
     _saveState();
     final transfer = TransferBinManager.instance;
     for (final t in trains) {
+      transfer.validateSlots('train_${t.id}', t.dollys.length);
       transfer.setSlotCount('train_${t.id}', t.dollys.length);
       for (int i = 0; i < t.dollys.length; i++) {
         final load = t.dollys[i].load;
@@ -89,6 +90,7 @@ class TrainNotifier extends StateNotifier<List<Train>> {
     ];
     _saveState();
     final transfer = TransferBinManager.instance;
+    transfer.validateSlots('train_${updated.id}', updated.dollys.length);
     transfer.setSlotCount('train_${updated.id}', updated.dollys.length);
     for (int i = 0; i < updated.dollys.length; i++) {
       final load = updated.dollys[i].load;


### PR DESCRIPTION
## Summary
- ensure slot reductions move ULDs from invalid positions to the transfer bin
- validate slot lists before resizing for ball deck, plane sequences, and trains
- add debug logging for moved ULDs

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68935f13ad688331b0a4ff4109acc9b1