### PR TITLE
Remove debug print from plane provider

### DIFF
--- a/lib/providers/plane_provider.dart
+++ b/lib/providers/plane_provider.dart
@@ -111,7 +111,6 @@ class PlaneNotifier extends StateNotifier<PlaneState> {
         final uld = current[i];
         if (uld != null) {
           transfer.addULD(uld);
-          debugPrint('Moved ULD ${uld.uld} from Plane slot $i to transfer bin');
         }
       }
     }


### PR DESCRIPTION
## Summary
- remove stray debug output from plane provider to avoid build errors

## Testing
- `dart format lib/providers/plane_provider.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893634e555c8331bf572e2e46cd3397