### PR TITLE
Fix 767-300 config C bottom slot label

### DIFF
--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -89,7 +89,7 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
     Aircraft('B763', 'Boeing 767-300 Freighter', [], [
       LoadingSequence('A', 'A', List.generate(17, (i) => i)),
       LoadingSequence('B', 'B', List.generate(13, (i) => i)),
-      LoadingSequence('C', 'C', List.generate(24, (i) => i)),
+      LoadingSequence('C', 'C', List.generate(20, (i) => i)),
     ]),
     Aircraft('B752', 'Boeing 757-200 Freighter', [], []),
   ];

--- a/lib/pages/plane_page.dart
+++ b/lib/pages/plane_page.dart
@@ -26,7 +26,7 @@ final List<Aircraft> aircraftList = [
   Aircraft('B763', 'Boeing 767-300 Freighter', [], [
     LoadingSequence('A', 'A', List.generate(17, (i) => i)),
     LoadingSequence('B', 'B', List.generate(13, (i) => i)),
-    LoadingSequence('C', 'C', List.generate(24, (i) => i)),
+    LoadingSequence('C', 'C', List.generate(20, (i) => i)),
   ]),
   Aircraft('B752', 'Boeing 757-200 Freighter', [], []),
 ];
@@ -621,7 +621,7 @@ class PlanePage extends ConsumerWidget {
           return 'B${index + 3}';
         case 'C':
           if (index == 0) return '1';
-          if (index == sequence.order.length - 1) return 'A17';
+          if (index == sequence.order.length - 1) return 'A13';
           final adj = index - 1;
           final row = adj ~/ 2 + 2;
           final side = adj % 2 == 0 ? 'L' : 'R';


### PR DESCRIPTION
## Summary
- Reduce Boeing 767-300 Freighter config C slot sequence to 20 positions
- Relabel the last slot in config C to display **A13** instead of A17

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68965c749d4c83318840e302fbf364f6