### PR TITLE
Fix 767-300 config C bottom row layout

### DIFF
--- a/lib/pages/plane_page.dart
+++ b/lib/pages/plane_page.dart
@@ -717,8 +717,8 @@ class PlanePage extends ConsumerWidget {
         case 'C':
           if (index == 0) return '1';
           if (sequence.order.length == 24) {
-            if (index == 22) return 'A13';
-            if (index == 23) return 'R12';
+            if (index == 22) return 'R12';
+            if (index == 23) return 'A13';
           } else if (index == sequence.order.length - 1) {
             return 'A13';
           }


### PR DESCRIPTION
## Summary
- Correct slot labels for 767-300 config C so R12 is placed above and A13 remains centered in the bottom row.

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6896d2f4eff08331902dfd734edbd7bc