### PR TITLE
Add door line overlay for 767-300 main deck

### DIFF
--- a/lib/pages/plane_page.dart
+++ b/lib/pages/plane_page.dart
@@ -272,11 +272,11 @@ class _PlanePageState extends ConsumerState<PlanePage> {
             top: _doorMarkerRect!.top,
             child: IgnorePointer(
               child: Container(
-                width: 22,
-                height: 3,
+                width: _doorMarkerRect!.width,
+                height: _doorMarkerRect!.height,
                 decoration: BoxDecoration(
                   color: Colors.white,
-                  borderRadius: BorderRadius.circular(1.5),
+                  borderRadius: BorderRadius.circular(2),
                 ),
               ),
             ),
@@ -328,8 +328,14 @@ class _PlanePageState extends ConsumerState<PlanePage> {
     final slotBox = key!.currentContext!.findRenderObject() as RenderBox;
     final stackBox = _gridKey.currentContext!.findRenderObject() as RenderBox;
     final slotPos = slotBox.localToGlobal(Offset.zero, ancestor: stackBox);
-    final anchor = Offset(slotPos.dx, slotPos.dy + slotBox.size.height / 2);
-    final rect = Rect.fromLTWH(anchor.dx - 6 - 22, anchor.dy - 1.5, 22, 3);
+    const lineWidth = 4.0;
+    const lineGap = 8.0;
+    final rect = Rect.fromLTWH(
+      slotPos.dx - lineGap - lineWidth,
+      slotPos.dy,
+      lineWidth,
+      slotBox.size.height,
+    );
     if (_doorMarkerRect != rect) {
       setState(() {
         _doorMarkerRect = rect;


### PR DESCRIPTION
## Summary
- Add vertical door overlay for the 767-300 main deck configurations A, B and C
- Position line using slot geometry and display it without affecting layout

## Testing
- `flutter test` *(fails: command not found)*
- `sudo apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_6897741dc1c883319e78ef20ea7cf551