### PR TITLE
Center 767-300 A/B slot column and align door marker

### DIFF
--- a/lib/pages/plane_page.dart
+++ b/lib/pages/plane_page.dart
@@ -590,6 +590,36 @@ class _PlanePageState extends ConsumerState<PlanePage> {
         ],
       );
     } else if (columns == 1) {
+      if (aircraft?.typeCode == 'B763' &&
+          (sequence.label == 'A' || sequence.label == 'B')) {
+        return LayoutBuilder(
+          builder: (context, constraints) {
+            const columnWidth = 100.0;
+            final availableWidth = constraints.maxWidth;
+            final centeredLeft = (availableWidth - columnWidth) / 2;
+            return Padding(
+              padding: EdgeInsets.only(left: centeredLeft),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: List.generate(slots.length, (i) {
+                  return Padding(
+                    padding: EdgeInsets.only(
+                      bottom: i == slots.length - 1 ? 0 : slotRunSpacing,
+                    ),
+                    child: _buildSlot(
+                      context,
+                      ref,
+                      i,
+                      _slotLabel(ref, sequence, i),
+                      outbound,
+                    ),
+                  );
+                }),
+              ),
+            );
+          },
+        );
+      }
       return Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: List.generate(slots.length, (i) {


### PR DESCRIPTION
## Summary
- center the single-column layout for Boeing 767-300 configs A and B using LayoutBuilder width
- door indicator remains tied to slot rectangles (A3/B3/3L) for correct placement

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68977ca85fd08331a83385f98f6bf23c