### PR TITLE
Center lower deck column for 767-300

### DIFF
--- a/lib/pages/plane_page.dart
+++ b/lib/pages/plane_page.dart
@@ -33,6 +33,10 @@ final List<Aircraft> aircraftList = [
 
 final lowerDeckviewProvider = StateProvider<bool>((ref) => false);
 
+// Width of a single column of ULD slots. Used to center single-column
+// layouts for both main deck and lower deck views.
+const double _kSingleColumnWidth = 100.0;
+
 class PlanePage extends ConsumerStatefulWidget {
   const PlanePage({super.key});
 
@@ -594,7 +598,7 @@ class _PlanePageState extends ConsumerState<PlanePage> {
           (sequence.label == 'A' || sequence.label == 'B')) {
         return LayoutBuilder(
           builder: (context, constraints) {
-            const columnWidth = 100.0;
+            const columnWidth = _kSingleColumnWidth;
             final availableWidth = constraints.maxWidth;
             final centeredLeft = (availableWidth - columnWidth) / 2;
             return Padding(
@@ -728,7 +732,12 @@ class _PlanePageState extends ConsumerState<PlanePage> {
         ),
       );
     }
-    return Column(children: children);
+    return Center(
+      child: SizedBox(
+        width: _kSingleColumnWidth,
+        child: Column(children: children),
+      ),
+    );
   }
 
   Widget _buildLowerDeckSlot(


### PR DESCRIPTION
## Summary
- add single-column width constant for deck layouts
- horizontally center 767-300 lower deck using shared width constant
- reuse shared width in main deck single-column centering

## Testing
- `flutter test` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68977f7eb65c8331aca4616886174fec