### PR TITLE
Adjust 767-300 lower deck door line offset

### DIFF
--- a/lib/pages/plane_page.dart
+++ b/lib/pages/plane_page.dart
@@ -395,14 +395,15 @@ class _PlanePageState extends ConsumerState<PlanePage> {
       return;
     }
     const thickness = 2.0;
+    const offset = 8.0;
     final marker14 = Rect.fromLTWH(
-      rect14.right - thickness,
+      rect14.right + offset,
       rect14.top,
       thickness,
       rect14.height,
     );
     final marker41 = Rect.fromLTWH(
-      rect41.right - thickness,
+      rect41.right + offset,
       rect41.top,
       thickness,
       rect41.height,


### PR DESCRIPTION
## Summary
- Offset lower deck door markers right of slots to improve visibility

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68978841441483319c98421cdee94101