### PR TITLE
Center 767‑200 main‑deck layouts for configs C and D (portrait & landscape)

### DIFF
--- a/lib/pages/plane_page.dart
+++ b/lib/pages/plane_page.dart
@@ -660,8 +660,10 @@ class _PlanePageState extends ConsumerState<PlanePage> {
         ],
       );
     } else if (columns == 1) {
-      if (aircraft?.typeCode == 'B763' &&
-          (sequence.label == 'A' || sequence.label == 'B')) {
+      if ((aircraft?.typeCode == 'B763' &&
+              (sequence.label == 'A' || sequence.label == 'B')) ||
+          (aircraft?.typeCode == 'B762' &&
+              (sequence.label == 'C' || sequence.label == 'D'))) {
         return LayoutBuilder(
           builder: (context, constraints) {
             const columnWidth = _kSingleColumnWidth;


### PR DESCRIPTION
## Summary
- Center 767-200 configs C and D horizontally by applying the single-column centering logic used on 767-300 A/B

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68978c54eae48331805b52cea40fb933