### PR TITLE
Fix 767-200 lower deck layout

### DIFF
--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -395,8 +395,14 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
       outboundSequenceLabel: cfg.label,
       outboundSequenceOrder: cfg.order,
       outboundSlots: List<model.StorageContainer?>.filled(cfg.order.length, null),
-      lowerInboundSlots: const [],
-      lowerOutboundSlots: const [],
+      lowerInboundSlots: List<model.StorageContainer?>.filled(
+        ac.typeCode == 'B762' ? 11 : 15,
+        null,
+      ),
+      lowerOutboundSlots: List<model.StorageContainer?>.filled(
+        ac.typeCode == 'B762' ? 11 : 15,
+        null,
+      ),
     );
 
     final planes = ref.read(planesProvider);

--- a/lib/pages/plane_page.dart
+++ b/lib/pages/plane_page.dart
@@ -37,6 +37,39 @@ final lowerDeckviewProvider = StateProvider<bool>((ref) => false);
 // layouts for both main deck and lower deck views.
 const double _kSingleColumnWidth = 100.0;
 
+// Lower deck labels for supported aircraft
+const List<String> _kB762LowerDeckLabels = [
+  '1AC',
+  '1BC',
+  '1CC',
+  '2DC',
+  '2EC',
+  '2FC',
+  '3AC',
+  '3BC',
+  '3CC',
+  '4DC',
+  '4EC',
+];
+
+const List<String> _kB763LowerDeckLabels = [
+  '11',
+  '12',
+  '13',
+  '14',
+  '21',
+  '22',
+  '23',
+  '24',
+  '31',
+  '32',
+  '33',
+  '34',
+  '41',
+  '42',
+  '43',
+];
+
 class PlanePage extends ConsumerStatefulWidget {
   const PlanePage({super.key});
 
@@ -768,32 +801,18 @@ class _PlanePageState extends ConsumerState<PlanePage> {
     bool outbound,
   ) {
     _slotKeys.clear();
-    final deck = ref.watch(lowerDeckProvider);
-    final slots = outbound ? deck.outboundSlots : deck.inboundSlots;
-    const labels = [
-      '11',
-      '12',
-      '13',
-      '14',
-      '21',
-      '22',
-      '23',
-      '24',
-      '31',
-      '32',
-      '33',
-      '34',
-      '41',
-      '42',
-      '43',
-    ];
+    ref.watch(lowerDeckProvider);
+    final aircraft = ref.watch(aircraftProvider);
+    final labels = aircraft?.typeCode == 'B762'
+        ? _kB762LowerDeckLabels
+        : _kB763LowerDeckLabels;
 
     final children = <Widget>[];
-    for (int i = 0; i < slots.length; i++) {
+    for (int i = 0; i < labels.length; i++) {
       children.add(
         Padding(
           padding: EdgeInsets.only(
-            bottom: i == slots.length - 1 ? 0 : slotRunSpacing,
+            bottom: i == labels.length - 1 ? 0 : slotRunSpacing,
           ),
           child: _buildLowerDeckSlot(context, ref, i, labels[i], outbound),
         ),

--- a/lib/providers/lower_deck_provider.dart
+++ b/lib/providers/lower_deck_provider.dart
@@ -37,9 +37,22 @@ class LowerDeckNotifier extends StateNotifier<LowerDeckState> {
         );
 
   void loadFromPlane(Plane plane) {
+    final required = plane.aircraftTypeCode == 'B762' ? 11 : 15;
+    var inbound = List<StorageContainer?>.from(plane.lowerInboundSlots);
+    var outbound = List<StorageContainer?>.from(plane.lowerOutboundSlots);
+    if (inbound.length < required) {
+      inbound.addAll(List.filled(required - inbound.length, null));
+    } else if (inbound.length > required) {
+      inbound = inbound.sublist(0, required);
+    }
+    if (outbound.length < required) {
+      outbound.addAll(List.filled(required - outbound.length, null));
+    } else if (outbound.length > required) {
+      outbound = outbound.sublist(0, required);
+    }
     state = LowerDeckState(
-      inboundSlots: List.from(plane.lowerInboundSlots),
-      outboundSlots: List.from(plane.lowerOutboundSlots),
+      inboundSlots: inbound,
+      outboundSlots: outbound,
     );
   }
 

--- a/lib/providers/plane_provider.dart
+++ b/lib/providers/plane_provider.dart
@@ -70,14 +70,28 @@ class PlaneNotifier extends StateNotifier<PlaneState> {
       plane.outboundSequenceLabel,
       plane.outboundSequenceOrder,
     );
+    final lowerRequired = plane.aircraftTypeCode == 'B762' ? 11 : 15;
+    var lowerInbound = List<StorageContainer?>.from(plane.lowerInboundSlots);
+    var lowerOutbound = List<StorageContainer?>.from(plane.lowerOutboundSlots);
+    if (lowerInbound.length < lowerRequired) {
+      lowerInbound.addAll(List.filled(lowerRequired - lowerInbound.length, null));
+    } else if (lowerInbound.length > lowerRequired) {
+      lowerInbound = lowerInbound.sublist(0, lowerRequired);
+    }
+    if (lowerOutbound.length < lowerRequired) {
+      lowerOutbound
+          .addAll(List.filled(lowerRequired - lowerOutbound.length, null));
+    } else if (lowerOutbound.length > lowerRequired) {
+      lowerOutbound = lowerOutbound.sublist(0, lowerRequired);
+    }
     state = PlaneState(
       inboundSequence: inboundSequence,
       outboundSequence: outboundSequence,
       configs: configs,
       inboundSlots: List.from(plane.inboundSlots),
       outboundSlots: List.from(plane.outboundSlots),
-      lowerInboundSlots: List.from(plane.lowerInboundSlots),
-      lowerOutboundSlots: List.from(plane.lowerOutboundSlots),
+      lowerInboundSlots: lowerInbound,
+      lowerOutboundSlots: lowerOutbound,
     );
   }
 


### PR DESCRIPTION
## Summary
- add dedicated 767-200 lower deck slot labels and use them for layout
- size lower deck slot lists to 11 for 767-200, 15 for other aircraft
- initialize new planes with correct lower deck slot count

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68979de2c4808331983d9bcbc2c3c19b