### PR TITLE
Ensure reactive storage slots

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,7 +38,8 @@ void main() async {
     Hive.openBox('tugBox'),
     Hive.openBox('tugsBox'),
     Hive.openBox('uldBox'),
-    Hive.openBox('storageBox'),
+    Hive.openBox('storage_config'),
+    Hive.openBox('storage_items'),
   ]);
 
   runApp(const ProviderScope(child: MyApp()));

--- a/lib/managers/transfer_bin_manager.dart
+++ b/lib/managers/transfer_bin_manager.dart
@@ -16,7 +16,8 @@ class TransferBinManager extends ChangeNotifier {
   static final TransferBinManager _instance = TransferBinManager._internal();
   static TransferBinManager get instance => _instance;
 
-  final Box _box = Hive.box('transferBox');
+  final Box _queueBox = Hive.box('transferBox');
+  final Box _slotsBox = Hive.box('storage_items');
   static const String _queueKey = 'queue';
   static const String _slotKey = 'slots';
 
@@ -24,11 +25,11 @@ class TransferBinManager extends ChangeNotifier {
   final Map<String, List<StorageContainer?>> _slots = {};
 
   TransferBinManager._internal() {
-    final storedQueue = _box.get(_queueKey);
+    final storedQueue = _queueBox.get(_queueKey);
     if (storedQueue != null && storedQueue is List) {
       _ulds = List<StorageContainer>.from(storedQueue);
     }
-    final storedSlots = _box.get(_slotKey);
+    final storedSlots = _slotsBox.get(_slotKey);
     if (storedSlots != null && storedSlots is Map) {
       for (final entry in storedSlots.entries) {
         _slots[entry.key] = List<StorageContainer?>.from(entry.value as List);
@@ -39,8 +40,8 @@ class TransferBinManager extends ChangeNotifier {
   List<StorageContainer> get ulds => List.unmodifiable(_ulds);
 
   void _save() {
-    _box.put(_queueKey, _ulds);
-    _box.put(_slotKey, _slots);
+    _queueBox.put(_queueKey, _ulds);
+    _slotsBox.put(_slotKey, _slots);
   }
 
   void addULD(StorageContainer uld) {
@@ -123,8 +124,7 @@ class TransferBinManager extends ChangeNotifier {
     for (int i = newSlotCount; i < slots.length; i++) {
       final c = slots[i];
       if (c != null) {
-        debugPrint(
-            'Moved ULD ${c.uld} from $pageId slot $i to transfer bin');
+        debugPrint('Moved ${c.id} to Transfer (index $i >= $newSlotCount)');
         containersToMove.add(c);
       }
     }

--- a/lib/models/container.dart
+++ b/lib/models/container.dart
@@ -3,6 +3,7 @@ import 'aircraft.dart';
 
 part 'container.g.dart';
 
+/// Serializable ULD container stored in Hive.
 @HiveType(typeId: 0)
 class StorageContainer extends HiveObject {
   @HiveField(0)

--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -109,7 +109,8 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
       'uldBox',
       'ballDeckBox',
       'transferBox',
-      'storageBox',
+      'storage_config',
+      'storage_items',
     ];
     for (final b in boxes) {
       if (!Hive.isBoxOpen(b)) {
@@ -152,7 +153,10 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
     _ballDeckCount = ref.read(ballDeckProvider).slots.length;
     
     // Get the current storage slot count from the provider
-    _storageCount = ref.read(storageProvider.notifier).getCurrentSlotCount();
+    _storageCount = ref
+        .read(storageProvider.notifier)
+        .getCurrentSlotCount()
+        .clamp(0, 50);
 
     final planes = ref.read(planesProvider);
     _planeDrafts = planes.map((p) {

--- a/lib/providers/storage_provider.dart
+++ b/lib/providers/storage_provider.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+
 import '../models/container.dart';
 import '../managers/transfer_bin_manager.dart';
 import '../managers/uld_placement_manager.dart';
@@ -11,35 +13,32 @@ final storageProvider =
 
 class StorageNotifier extends StateNotifier<List<StorageContainer?>> {
   static const _pageId = 'storage';
-  static const _slotCountKey = 'storageSlotCount';
+  static const _slotCountKey = 'slotCount';
   final TransferBinManager _manager = TransferBinManager.instance;
-  Box? _box;
+  late final Box _box;
+  late final ValueListenable _listenable;
 
   StorageNotifier() : super([]) {
     _initializeBox();
   }
 
   void _initializeBox() {
-    // Since the box should already be opened in main.dart, we can access it directly
     try {
-      _box = Hive.box('storageBox');
-      
-      // Load the persisted slot count
-      final savedSlotCount = _box!.get(_slotCountKey, defaultValue: 0) as int;
-      
-      // Initialize the manager with the saved slot count
+      _box = Hive.box('storage_config');
+
+      final savedSlotCount =
+          _box.get(_slotCountKey, defaultValue: 0) as int? ?? 0;
       if (savedSlotCount > 0) {
         _manager.setSlotCount(_pageId, savedSlotCount);
       }
-      
-      // Set initial state
       state = _manager.getSlots(_pageId);
-      
-      // Listen for changes
+
       _manager.addListener(_update);
+
+      _listenable = _box.listenable(keys: [_slotCountKey]);
+      _listenable.addListener(_onSlotCountChanged);
     } catch (e) {
       print('Error initializing storage box: $e');
-      // Fallback to empty state
       state = [];
     }
   }
@@ -48,28 +47,30 @@ class StorageNotifier extends StateNotifier<List<StorageContainer?>> {
     state = _manager.getSlots(_pageId);
   }
 
+  void _onSlotCountChanged() {
+    final count = _box.get(_slotCountKey, defaultValue: 0) as int? ?? 0;
+    _manager.setSlotCount(_pageId, count);
+    state = _manager.getSlots(_pageId);
+  }
+
   @override
   void dispose() {
     _manager.removeListener(_update);
+    _listenable.removeListener(_onSlotCountChanged);
     super.dispose();
   }
 
   void setSize(int count) {
-    // Save the slot count to persistence
-    _box?.put(_slotCountKey, count);
-    
-    // Validate slots first - this moves excess ULDs to transfer bin
+    _box.put(_slotCountKey, count);
+    debugPrint('Storage slotCount set to $count');
+
     _manager.validateSlots(_pageId, count);
-
-    // Update the state to reflect the new slots
     state = _manager.getSlots(_pageId);
-
-    // Keep placement tracking in sync
     ULDPlacementManager().updateSlotCount('Storage', count);
   }
 
   int getCurrentSlotCount() {
-    return _box?.get(_slotCountKey, defaultValue: 0) as int? ?? 0;
+    return _box.get(_slotCountKey, defaultValue: 0) as int? ?? 0;
   }
 
   void placeContainer(int idx, StorageContainer container) {


### PR DESCRIPTION
## Summary
- Initialize Hive storage boxes before app startup
- Persist and listen to storage slot count for reactive updates
- Use single TransferBinManager with migration of displaced ULDs

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_6897a6d7af208331837948e86d5d5ae4