### PR TITLE
Fix Train page Transfer bin layout and padding

### DIFF
--- a/lib/pages/train_page.dart
+++ b/lib/pages/train_page.dart
@@ -12,6 +12,7 @@ import '../widgets/color_palette.dart';
 import '../widgets/transfer_menu.dart';
 import '../widgets/transfer_area.dart';
 import '../utils/uld_mover.dart';
+import '../theme/layout_constants.dart';
 
 class _TrainDraft {
   String id;
@@ -156,15 +157,20 @@ class _TrainPageState extends ConsumerState<TrainPage>
     const topBarHeight = 60.0;
 
     final media = MediaQuery.of(context);
+    final bottomPadding = kTransferBinHeight +
+        MediaQuery.viewPaddingOf(context).bottom +
+        kBottomScrollBuffer;
     final availableHeight = media.size.height -
         media.padding.top -
         topBarHeight -
         kTextTabBarHeight -
-        60;
+        kTransferBinHeight -
+        media.padding.bottom;
     final listHeight = availableHeight - 72;
 
     return Scaffold(
       backgroundColor: Colors.black,
+      bottomNavigationBar: const TransferArea(),
       body: SafeArea(
         bottom: false,
         child: Column(
@@ -224,6 +230,7 @@ class _TrainPageState extends ConsumerState<TrainPage>
           ),
           Expanded(
             child: SingleChildScrollView(
+              padding: EdgeInsets.only(bottom: bottomPadding),
               child: Column(
                 children: [
                   Container(
@@ -272,7 +279,6 @@ class _TrainPageState extends ConsumerState<TrainPage>
               ),
             ),
           ),
-          const SizedBox(height: 60, child: TransferArea()),
         ],
       ),
     ),
@@ -304,8 +310,11 @@ class _TrainPageState extends ConsumerState<TrainPage>
   }
 
   Widget _buildDollyStack(BuildContext context, Train train) {
+    final bottomPadding = kTransferBinHeight +
+        MediaQuery.viewPaddingOf(context).bottom +
+        kBottomScrollBuffer;
     return ListView.builder(
-      padding: EdgeInsets.zero,
+      padding: EdgeInsets.only(bottom: bottomPadding),
       itemCount: train.dollyCount,
       itemBuilder: (context, index) {
         final dolly = train.dollys[index];

--- a/lib/theme/layout_constants.dart
+++ b/lib/theme/layout_constants.dart
@@ -1,0 +1,2 @@
+const double kTransferBinHeight = 48.0;
+const double kBottomScrollBuffer = 16.0;

--- a/lib/widgets/transfer_area.dart
+++ b/lib/widgets/transfer_area.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/container.dart';
 import '../providers/transfer_bin_provider.dart';
 import '../utils/uld_mover.dart';
+import '../theme/layout_constants.dart';
 
 class TransferArea extends ConsumerWidget {
   const TransferArea({super.key});
@@ -23,22 +24,25 @@ class TransferArea extends ConsumerWidget {
       },
       builder: (context, cand, rej) {
         final isActive = cand.isNotEmpty;
-        return Container(
-          height: 48,
-          color: Colors.grey[850],
-          alignment: Alignment.center,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(Icons.inbox, color: isActive ? Colors.yellow : Colors.white),
-              const SizedBox(width: 8),
-              Text(
-                'Transfer (${queue.length})',
-                style: TextStyle(
-                  color: isActive ? Colors.yellow : Colors.white,
+        return SizedBox(
+          height: kTransferBinHeight,
+          child: Container(
+            color: Colors.grey[850],
+            alignment: Alignment.center,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.inbox,
+                    color: isActive ? Colors.yellow : Colors.white),
+                const SizedBox(width: 8),
+                Text(
+                  'Transfer (${queue.length})',
+                  style: TextStyle(
+                    color: isActive ? Colors.yellow : Colors.white,
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         );
       },


### PR DESCRIPTION
## Summary
- centralize Transfer bin sizing in `layout_constants.dart`
- place TransferArea in Train page `Scaffold.bottomNavigationBar`
- pad Train page scroll areas so last row is fully visible

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f43b20464833198dcf6c4822e8cc0