### PR TITLE
Resolve AGP version conflict by removing legacy declarations

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -18,8 +18,6 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
 }
 
 include(":app")


### PR DESCRIPTION
## Summary
- remove extra AGP and Kotlin plugin declarations in `android/settings.gradle.kts`
- rely on project `build.gradle.kts` for AGP 8.3.2 and Kotlin 1.9.24
- ensure Gradle wrapper targets 8.4

## Testing
- `flutter clean` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter run` *(fails: command not found)*
- `gradle -p android help` *(fails: /workspace/Ramp-Loading-App/android/local.properties (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_68a2825b1a2c833180d1adc906eb76c7