### PR TITLE
fix: resolve gradle plugin conflicts for AGP and Kotlin

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,7 +1,4 @@
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.application") version "8.3.2" apply false
-    id("com.android.library") version "8.3.2" apply false
     id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+    id("dev.flutter.flutter-gradle-plugin") apply false
 }
 
 allprojects {


### PR DESCRIPTION
## Summary
- streamline Gradle plugin setup so AGP and Kotlin versions are declared once
- ensure Flutter Gradle plugin is managed at the root build file

## Testing
- `flutter clean` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a28b68f5ec833188215895f37b3d53