### PR TITLE
chore: upgrade Android build to Gradle 8.6 and Kotlin 1.9.22

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.application") version "8.3.2" apply false
     id("com.android.library")    version "8.3.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
     id("dev.flutter.flutter-gradle-plugin") apply false
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip


### PR DESCRIPTION
## Summary
- upgrade Gradle wrapper to 8.6
- align Kotlin plugin version with Gradle’s embedded Kotlin 1.9.20+

## Testing
- ⚠️ `flutter clean` *(command not found)*
- ⚠️ `flutter pub get` *(command not found)*
- ⚠️ `gradle -p android wrapper --gradle-version 8.6 --distribution-type all` *(error: included Flutter plugin build not found)*
- ⚠️ `gradle -p android -version` *(uses global Gradle 8.14.3; wrapper not executed)*

------
https://chatgpt.com/codex/tasks/task_e_68acbbcb024083319986ec94970454c8