### PR TITLE
Add pallets checkbox and blue outline for ULDs

### DIFF
--- a/lib/models/container.dart
+++ b/lib/models/container.dart
@@ -18,6 +18,7 @@ class StorageContainer extends HiveObject {
   final SizeEnum size;
   int weightKg;
   bool dangerousGoods;
+  bool hasPallets;
   final int? colorIndex;
 
   StorageContainer({
@@ -28,6 +29,7 @@ class StorageContainer extends HiveObject {
     required this.size,
     this.weightKg = 0,
     this.dangerousGoods = false,
+    this.hasPallets = false,
     this.colorIndex,
   }) : label = label ?? uld ?? '';
 
@@ -53,14 +55,15 @@ class StorageContainerAdapter extends TypeAdapter<StorageContainer> {
       size: fields[3] as SizeEnum,
       weightKg: fields[4] as int,
       dangerousGoods: fields[5] as bool,
-      colorIndex: fields[6] as int?,
+      hasPallets: fields[6] as bool? ?? false,
+      colorIndex: fields[7] as int?,
     );
   }
 
   @override
   void write(BinaryWriter writer, StorageContainer obj) {
     writer
-      ..writeByte(7)
+      ..writeByte(8)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -74,6 +77,8 @@ class StorageContainerAdapter extends TypeAdapter<StorageContainer> {
       ..writeByte(5)
       ..write(obj.dangerousGoods)
       ..writeByte(6)
+      ..write(obj.hasPallets)
+      ..writeByte(7)
       ..write(obj.colorIndex);
   }
 }

--- a/lib/pages/ball_deck_page.dart
+++ b/lib/pages/ball_deck_page.dart
@@ -273,6 +273,7 @@ class _AddUldDialogState extends ConsumerState<AddUldDialog> {
                     size: SizeEnum.PAG_88x125,
                     weightKg: 0,
                     dangerousGoods: false,
+                    hasPallets: false,
                     colorIndex: 0,
                   ),
                 );

--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -257,6 +257,7 @@ class _ConfigPageState extends ConsumerState<ConfigPage> {
                   size: SizeEnum.PAG_88x125,
                   weightKg: 0,
                   dangerousGoods: false,
+                  hasPallets: false,
                   colorIndex: 0,
                 );
                 switch (destination) {

--- a/lib/widgets/uld_chip.dart
+++ b/lib/widgets/uld_chip.dart
@@ -50,9 +50,20 @@ class _UldChipState extends State<UldChip> {
     } catch (_) {}
   }
 
+  void _togglePallets(bool? value) {
+    if (value == null) return;
+    setState(() {
+      widget.uld.hasPallets = value;
+    });
+    try {
+      widget.uld.save();
+    } catch (_) {}
+  }
+
   @override
   Widget build(BuildContext context) {
     final hasDg = widget.uld.dangerousGoods;
+    final hasPallets = widget.uld.hasPallets;
 
     final inner = Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -64,16 +75,31 @@ class _UldChipState extends State<UldChip> {
       ),
     );
 
-    Widget decorated = DottedBorder(
-      color: Colors.white,
-      strokeWidth: 2,
-      dashPattern: const [4, 4],
-      borderType: BorderType.RRect,
-      radius: const Radius.circular(8),
-      child: inner,
-    );
+    Widget decorated;
 
-    if (hasDg) {
+    if (hasDg && hasPallets) {
+      decorated = Container(
+        decoration: BoxDecoration(
+          border: Border.all(color: Colors.red, width: 2),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: DottedBorder(
+          color: Colors.blue,
+          strokeWidth: 2,
+          dashPattern: const [4, 4],
+          borderType: BorderType.RRect,
+          radius: const Radius.circular(8),
+          child: DottedBorder(
+            color: Colors.white,
+            strokeWidth: 2,
+            dashPattern: const [4, 4],
+            borderType: BorderType.RRect,
+            radius: const Radius.circular(8),
+            child: inner,
+          ),
+        ),
+      );
+    } else if (hasDg) {
       decorated = Container(
         decoration: BoxDecoration(
           border: Border.all(color: Colors.red, width: 2),
@@ -88,6 +114,24 @@ class _UldChipState extends State<UldChip> {
           child: inner,
         ),
       );
+    } else if (hasPallets) {
+      decorated = DottedBorder(
+        color: Colors.blue,
+        strokeWidth: 2,
+        dashPattern: const [4, 4],
+        borderType: BorderType.RRect,
+        radius: const Radius.circular(8),
+        child: inner,
+      );
+    } else {
+      decorated = DottedBorder(
+        color: Colors.white,
+        strokeWidth: 2,
+        dashPattern: const [4, 4],
+        borderType: BorderType.RRect,
+        radius: const Radius.circular(8),
+        child: inner,
+      );
     }
 
     return Stack(
@@ -95,15 +139,40 @@ class _UldChipState extends State<UldChip> {
         decorated,
         Positioned(
           top: -4,
+          left: -4,
+          child: Column(
+            children: [
+              Transform.scale(
+                scale: 0.8,
+                child: Checkbox(
+                  value: hasPallets,
+                  onChanged: _togglePallets,
+                  activeColor: Colors.blue,
+                  checkColor: Colors.white,
+                ),
+              ),
+              const Text('P',
+                  style: TextStyle(color: Colors.white, fontSize: 10)),
+            ],
+          ),
+        ),
+        Positioned(
+          top: -4,
           right: -4,
-          child: Transform.scale(
-            scale: 0.8,
-            child: Checkbox(
-              value: hasDg,
-              onChanged: _toggleDg,
-              activeColor: Colors.red,
-              checkColor: Colors.white,
-            ),
+          child: Column(
+            children: [
+              Transform.scale(
+                scale: 0.8,
+                child: Checkbox(
+                  value: hasDg,
+                  onChanged: _toggleDg,
+                  activeColor: Colors.red,
+                  checkColor: Colors.white,
+                ),
+              ),
+              const Text('DG',
+                  style: TextStyle(color: Colors.white, fontSize: 10)),
+            ],
           ),
         ),
       ],

--- a/lib/widgets/uld_detail_dialog.dart
+++ b/lib/widgets/uld_detail_dialog.dart
@@ -36,32 +36,44 @@ class UldDetailDialog extends StatelessWidget {
                   if (checked == true) {
                     final confirm = await showDialog<bool>(
                       context: context,
-                      builder:
-                          (_) => AlertDialog(
-                            backgroundColor: Colors.black,
-                            title: const Text(
-                              'Confirm',
-                              style: TextStyle(color: Colors.white),
-                            ),
-                            content: const Text(
-                              'Are you sure you want to mark this ULD as Dangerous Goods?',
-                              style: TextStyle(color: Colors.white70),
-                            ),
-                            actions: [
-                              TextButton(
-                                onPressed: () => Navigator.pop(context, false),
-                                child: const Text('Cancel'),
-                              ),
-                              TextButton(
-                                onPressed: () => Navigator.pop(context, true),
-                                child: const Text('Confirm'),
-                              ),
-                            ],
+                      builder: (_) => AlertDialog(
+                        backgroundColor: Colors.black,
+                        title: const Text(
+                          'Confirm',
+                          style: TextStyle(color: Colors.white),
+                        ),
+                        content: const Text(
+                          'Are you sure you want to mark this ULD as Dangerous Goods?',
+                          style: TextStyle(color: Colors.white70),
+                        ),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.pop(context, false),
+                            child: const Text('Cancel'),
                           ),
+                          TextButton(
+                            onPressed: () => Navigator.pop(context, true),
+                            child: const Text('Confirm'),
+                          ),
+                        ],
+                      ),
                     );
                     if (confirm != true) return;
                   }
                   container.dangerousGoods = checked ?? false;
+                  onUpdate();
+                  if (!context.mounted) return;
+                  Navigator.pop(context);
+                },
+              ),
+              const SizedBox(width: 16),
+              const Text('P', style: TextStyle(color: Colors.white)),
+              Checkbox(
+                value: container.hasPallets,
+                activeColor: Colors.blue,
+                checkColor: Colors.white,
+                onChanged: (checked) {
+                  container.hasPallets = checked ?? false;
                   onUpdate();
                   if (!context.mounted) return;
                   Navigator.pop(context);


### PR DESCRIPTION
## Summary
- allow ULDs to track pallet presence with a new `hasPallets` field persisted to Hive
- show left-side "P" checkbox that toggles a blue dotted border
- overlay pallets and dangerous goods indicators so both outlines render together

## Testing
- `dart format lib/models/container.dart lib/widgets/uld_chip.dart lib/widgets/uld_detail_dialog.dart lib/pages/ball_deck_page.dart lib/pages/config_page.dart` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3deecc6908331a2a9488810d5c71b