### PR TITLE
Fix checkbox/label overlap across ULD chip

### DIFF
--- a/lib/widgets/uld_chip.dart
+++ b/lib/widgets/uld_chip.dart
@@ -94,6 +94,7 @@ class _UldChipState extends State<UldChip> {
     final hasPallets = widget.uld.hasPallets;
     final content = Column(
       mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Row(
@@ -115,7 +116,7 @@ class _UldChipState extends State<UldChip> {
             ),
           ],
         ),
-        const SizedBox(height: 4),
+        const SizedBox(height: 6),
         Text(
           widget.uld.uld,
           style: const TextStyle(fontSize: 12, color: Colors.white),
@@ -126,7 +127,7 @@ class _UldChipState extends State<UldChip> {
 
     final inner = Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      alignment: Alignment.center,
+      alignment: Alignment.topCenter,
       child: content,
     );
 


### PR DESCRIPTION
## Summary
- Prevent ULD label from overlapping P and DG checkboxes by aligning content to the top and adding extra spacing.

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ea93bda88331bc42f0d6a85d8627