### PR TITLE
Fix ULD checkbox and label alignment with fixed layout

### DIFF
--- a/lib/widgets/uld_chip.dart
+++ b/lib/widgets/uld_chip.dart
@@ -96,7 +96,7 @@ class _UldChipState extends State<UldChip> {
               onChanged: _togglePallets,
               activeColor: Colors.blue,
             ),
-            const SizedBox(width: 4),
+            const SizedBox(width: 6),
             _buildCheckbox(
               value: hasDg,
               onChanged: _toggleDg,
@@ -106,12 +106,15 @@ class _UldChipState extends State<UldChip> {
         ),
         const SizedBox(height: 4),
         Flexible(
-          child: Text(
-            widget.uld.uld,
-            style: const TextStyle(fontSize: 12, color: Colors.white),
-            textAlign: TextAlign.center,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 2),
+            child: Text(
+              widget.uld.uld,
+              style: const TextStyle(fontSize: 12, color: Colors.white),
+              textAlign: TextAlign.center,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         ),
       ],
@@ -119,9 +122,12 @@ class _UldChipState extends State<UldChip> {
 
     final inner = Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      child: Align(
-        alignment: Alignment.topCenter,
-        child: content,
+      child: SizedBox(
+        height: 70,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 60, maxHeight: 70),
+          child: content,
+        ),
       ),
     );
 


### PR DESCRIPTION
## Summary
- enforce strict spacing within ULD chips using fixed-height container and constraints
- center P/DG checkboxes in a top row with padding-separated label underneath

## Testing
- `dart format lib/widgets/uld_chip.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ef850c7c83318cb62a5705bdb0fb