### PR TITLE
Add pallets checkbox and dual border support

### DIFF
--- a/lib/models/container.dart
+++ b/lib/models/container.dart
@@ -18,6 +18,7 @@ class StorageContainer extends HiveObject {
   final SizeEnum size;
   int weightKg;
   bool dangerousGoods;
+  bool hasPallets;
   final int? colorIndex;
 
   StorageContainer({
@@ -28,6 +29,7 @@ class StorageContainer extends HiveObject {
     required this.size,
     this.weightKg = 0,
     this.dangerousGoods = false,
+    this.hasPallets = false,
     this.colorIndex,
   }) : label = label ?? uld ?? '';
 
@@ -54,13 +56,14 @@ class StorageContainerAdapter extends TypeAdapter<StorageContainer> {
       weightKg: fields[4] as int,
       dangerousGoods: fields[5] as bool,
       colorIndex: fields[6] as int?,
+      hasPallets: fields[7] as bool? ?? false,
     );
   }
 
   @override
   void write(BinaryWriter writer, StorageContainer obj) {
     writer
-      ..writeByte(7)
+      ..writeByte(8)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -74,7 +77,9 @@ class StorageContainerAdapter extends TypeAdapter<StorageContainer> {
       ..writeByte(5)
       ..write(obj.dangerousGoods)
       ..writeByte(6)
-      ..write(obj.colorIndex);
+      ..write(obj.colorIndex)
+      ..writeByte(7)
+      ..write(obj.hasPallets);
   }
 }
 

--- a/lib/providers/uld_provider.dart
+++ b/lib/providers/uld_provider.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/container.dart';
+
+final uldProvider = ChangeNotifierProvider((ref) => UldNotifier());
+
+class UldNotifier extends ChangeNotifier {
+  void togglePallets(StorageContainer uld, bool value) {
+    uld.hasPallets = value;
+    try {
+      uld.save();
+    } catch (_) {}
+    notifyListeners();
+  }
+}

--- a/lib/widgets/uld_chip.dart
+++ b/lib/widgets/uld_chip.dart
@@ -50,9 +50,20 @@ class _UldChipState extends State<UldChip> {
     } catch (_) {}
   }
 
+  void _togglePallets(bool? value) {
+    if (value == null) return;
+    setState(() {
+      widget.uld.hasPallets = value;
+    });
+    try {
+      widget.uld.save();
+    } catch (_) {}
+  }
+
   @override
   Widget build(BuildContext context) {
     final hasDg = widget.uld.dangerousGoods;
+    final hasPallets = widget.uld.hasPallets;
 
     final inner = Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -64,29 +75,35 @@ class _UldChipState extends State<UldChip> {
       ),
     );
 
-    Widget decorated = DottedBorder(
-      color: Colors.white,
-      strokeWidth: 2,
-      dashPattern: const [4, 4],
-      borderType: BorderType.RRect,
-      radius: const Radius.circular(8),
-      child: inner,
-    );
-
+    Widget decorated = inner;
+    if (hasPallets) {
+      decorated = DottedBorder(
+        color: Colors.blue,
+        strokeWidth: 2,
+        dashPattern: const [4, 4],
+        borderType: BorderType.RRect,
+        radius: const Radius.circular(8),
+        child: decorated,
+      );
+    }
     if (hasDg) {
-      decorated = Container(
-        decoration: BoxDecoration(
-          border: Border.all(color: Colors.red, width: 2),
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: DottedBorder(
-          color: Colors.white,
-          strokeWidth: 2,
-          dashPattern: const [4, 4],
-          borderType: BorderType.RRect,
-          radius: const Radius.circular(8),
-          child: inner,
-        ),
+      decorated = DottedBorder(
+        color: Colors.red,
+        strokeWidth: 2,
+        dashPattern: const [4, 4],
+        borderType: BorderType.RRect,
+        radius: const Radius.circular(8),
+        child: decorated,
+      );
+    }
+    if (!hasDg && !hasPallets) {
+      decorated = DottedBorder(
+        color: Colors.white,
+        strokeWidth: 2,
+        dashPattern: const [4, 4],
+        borderType: BorderType.RRect,
+        radius: const Radius.circular(8),
+        child: decorated,
       );
     }
 
@@ -102,6 +119,19 @@ class _UldChipState extends State<UldChip> {
               value: hasDg,
               onChanged: _toggleDg,
               activeColor: Colors.red,
+              checkColor: Colors.white,
+            ),
+          ),
+        ),
+        Positioned(
+          top: -4,
+          left: -4,
+          child: Transform.scale(
+            scale: 0.8,
+            child: Checkbox(
+              value: hasPallets,
+              onChanged: _togglePallets,
+              activeColor: Colors.blue,
               checkColor: Colors.white,
             ),
           ),


### PR DESCRIPTION
## Summary
- add `hasPallets` field to `StorageContainer` and update Hive adapter
- show pallets checkbox with blue border and refine DG styling
- introduce basic provider for pallet toggling

## Testing
- `flutter pub run build_runner build` *(fails: command not found)*
- `dart run build_runner build` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b488de91bc8331aa3e682fcad489b9