### PR TITLE
Move ULD slot indicator to bottom-left corner

### DIFF
--- a/lib/pages/plane_page.dart
+++ b/lib/pages/plane_page.dart
@@ -998,7 +998,7 @@ class _PlanePageState extends ConsumerState<PlanePage> {
                 : Stack(
                     children: [
                       Positioned(
-                        top: 2,
+                        bottom: 2,
                         left: 2,
                         child: Container(
                           padding: const EdgeInsets.symmetric(
@@ -1155,7 +1155,7 @@ class _PlanePageState extends ConsumerState<PlanePage> {
                   : Stack(
                       children: [
                         Positioned(
-                          top: 2,
+                          bottom: 2,
                           left: 2,
                           child: Container(
                             padding: const EdgeInsets.symmetric(


### PR DESCRIPTION
## Summary
- Reposition slot indicator within ULD slot widgets so the label displays at the bottom-left instead of the top-left.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b48dd8a4dc8331a70ae6002f3f90f8